### PR TITLE
fix fold_split bug

### DIFF
--- a/lib/str.ml
+++ b/lib/str.ml
@@ -111,7 +111,7 @@ let fold_split re text ~init ~f =
         if pos > start then
           let str = `Token (sub start pos) in
           let delim  = `Delim (s) in
-          split match_end (f (f acc delim) str)
+          split match_end (f (f acc str) delim)
         else
           split match_end (f acc (`Delim s))
   in split 0 init


### PR DESCRIPTION
``` ocaml
let re = Humane_re.Str.regexp "x" in
Humane_re.Str.fold_split re "axbxc" ~init:[] ~f:(fun acc ->
    function `Delim s | `Token s -> s#str :: acc);;
```

Before:
`- : string list = ["c"; "b"; "x"; "a"; "x"]`
After:
`- : string list = ["c"; "x"; "b"; "x"; "a"]`
